### PR TITLE
Added the extra jvmargs to the Dockerfile and documented them on the …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@
 
 FROM stocksoftware/glassfish:latest
 
-CMD /opt/glassfish/mq/bin/imqbrokerd -bgnd -autorestart -tty -name MessageBroker -Dimq.service.activelist=admin,jms -Dimq.portmapper.port=${IMQ_PORTMAPPER_PORT}
+CMD /opt/glassfish/mq/bin/imqbrokerd -bgnd -autorestart -tty -name MessageBroker -Dimq.service.activelist=admin,jms -Dimq.portmapper.port=${IMQ_PORTMAPPER_PORT} -Dimq.jms.tcp.port=${IMQ_JMS_TCP_PORT} -Dimq.admin.tcp.port=${IMQ_ADMIN_TCP_PORT}

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ A minimal docker image designed to provide a openmq message broker useful for te
 
 Example:
 
-    docker run -it --rm stocksoftware/openmq:latest
+    docker run --name openmq -e IMQ_PORTMAPPER_PORT=7676 -e IMQ_JMS_TCP_PORT=40000 -e IMQ_ADMIN_TCP_PORT=50000 -p 7676:7676 -p 40000:40000 -p 50000:50000 -d --restart=unless-stopped crendon/openmq:latest


### PR DESCRIPTION
This very small tweak allows for the user to pass environment variables to specify which **imq.jms.tcp.port** and **imq.admin.tcp.port** to use.

This follows the example on from the use presented for IMQ_PORTMAPPER_PORT. 